### PR TITLE
Add Pulse#take and Pulse#takeWhile operators

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,6 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.kotlin.test.core)
             implementation(libs.kotlinx.coroutines.test)
-            implementation(libs.turbine)
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,6 @@ dokka = "1.9.10"
 kotlin = "1.9.21"
 kotlinx-coroutines = "1.8.0-RC2"
 kotlinx-datetime = "0.5.0"
-turbine = "1.0.0"
 publish = "0.25.3"
 
 [libraries]
@@ -11,7 +10,6 @@ kotlin-test-core = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = 
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
-turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/src/commonMain/kotlin/io/github/kevincianfarini/cardiologist/Pulse.kt
+++ b/src/commonMain/kotlin/io/github/kevincianfarini/cardiologist/Pulse.kt
@@ -4,6 +4,8 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Instant
 import kotlin.jvm.JvmInline
@@ -12,7 +14,19 @@ import kotlin.jvm.JvmInline
  * A [Pulse] is a cadence which informs consumers when to execute work by calling [Pulse.beat].
  */
 @JvmInline
-public value class Pulse internal constructor(internal val flow: Flow<Instant>) {
+public value class Pulse internal constructor(private val flow: Flow<Instant>) {
+
+    /**
+     * Returns a pulse that beats [count] times.
+     *
+     * @throws IllegalArgumentException is count is not positive.
+     */
+    public fun take(count: Int): Pulse = Pulse(flow.take(count))
+
+    /**
+     * Returns a pulse that beats while [predicate] is satisfied.
+     */
+    public fun takeWhile(predicate: (Instant) -> Boolean): Pulse = Pulse(flow.takeWhile(predicate))
 
     /**
      * Reinvoke [action] every time this Pulse is set to execute.

--- a/src/commonTest/kotlin/io/github/kevincianfarini/cardiologist/PulseTests.kt
+++ b/src/commonTest/kotlin/io/github/kevincianfarini/cardiologist/PulseTests.kt
@@ -1,6 +1,5 @@
 package io.github.kevincianfarini.cardiologist
 
-import app.cash.turbine.test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.testTimeSource
@@ -15,40 +14,36 @@ import kotlin.time.measureTime
 class PulseTests {
 
     @Test fun durationPulse_emits_initial_instant_before_delaying() = runTest {
-        testClock.intervalPulse(5.seconds).flow.test {
-            assertEquals(
-                expected = 0.seconds,
-                actual = testTimeSource.measureTime { awaitItem() }
-            )
-        }
+        assertEquals(
+            expected = 0.seconds,
+            actual = testTimeSource.measureTime {
+                testClock.intervalPulse(5.seconds).take(1).beat { }
+            }
+        )
     }
 
     @Test fun durationPulse_emits_subsequent_instants_after_delaying() = runTest {
-        testClock.intervalPulse(5.seconds).flow.test {
-            skipItems(1)
-            assertEquals(
-                expected = 5.seconds,
-                actual = testTimeSource.measureTime { awaitItem() }
-            )
-        }
+        assertEquals(
+            expected = 5.seconds,
+            actual = testTimeSource.measureTime {
+                testClock.intervalPulse(5.seconds).take(2).beat { }
+            }
+        )
     }
 
     @Test fun periodPulse_emits_initial_instant_before_delaying() = runTest {
-        testClock.intervalPulse(DateTimePeriod(seconds = 5), TimeZone.UTC).flow.test {
-            assertEquals(
-                expected = 0.seconds,
-                actual = testTimeSource.measureTime { awaitItem() }
-            )
-        }
+        val pulse = testClock.intervalPulse(DateTimePeriod(seconds = 5), TimeZone.UTC).take(1)
+        assertEquals(
+            expected = 0.seconds,
+            actual = testTimeSource.measureTime { pulse.beat { } }
+        )
     }
 
     @Test fun periodPulse_emits_subsequent_instants_after_delaying() = runTest {
-        testClock.intervalPulse(DateTimePeriod(seconds = 5), TimeZone.UTC).flow.test {
-            skipItems(1)
-            assertEquals(
-                expected = 5.seconds,
-                actual = testTimeSource.measureTime { awaitItem() }
-            )
-        }
+        val pulse = testClock.intervalPulse(DateTimePeriod(seconds = 5), TimeZone.UTC).take(2)
+        assertEquals(
+            expected = 5.seconds,
+            actual = testTimeSource.measureTime { pulse.beat { } }
+        )
     }
 }


### PR DESCRIPTION
This commit also removes our dependency on the turbine
testing library. We now test directly with Pulse#beat.

Closes #13
